### PR TITLE
implement the adapter API for assert-rails adapter gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ AssertRails adapter for Rails 4.  See https://github.com/redding/assert-rails fo
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+### Reset the test db for test runs
+
+```ruby
+# in test/helper.rb
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+
+require "assert-rails4"
+AssertRails.reset_db
+```
 
 ## Installation
 

--- a/lib/assert-rails4.rb
+++ b/lib/assert-rails4.rb
@@ -1,4 +1,9 @@
+require "assert-rails"
+
 require "assert-rails4/version"
+require "assert-rails4/adapter"
 
 module AssertRails4
 end
+
+AssertRails.adapter(AssertRails4::Adapter.new)

--- a/lib/assert-rails4/adapter.rb
+++ b/lib/assert-rails4/adapter.rb
@@ -1,0 +1,16 @@
+require "active_record"
+require "active_record/migration"
+require "assert-rails/adapter"
+
+module AssertRails4
+
+  class Adapter
+    include AssertRails::Adapter
+
+    def reset_db
+      ActiveRecord::Migration.maintain_test_schema!
+    end
+
+  end
+
+end

--- a/test/unit/adapter_tests.rb
+++ b/test/unit/adapter_tests.rb
@@ -1,0 +1,45 @@
+require "assert"
+require "assert-rails4/adapter"
+
+require "active_record"
+require "active_record/migration"
+
+class AssertRails4::Adapter
+
+  class UnitTests < Assert::Context
+    desc "AssertRails4::Adapter"
+    setup do
+      @class = AssertRails4::Adapter
+    end
+    subject{ @class }
+
+    should "mixin AssertRails::Adapter" do
+      assert_includes AssertRails::Adapter, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @adapter = @class.new
+    end
+    subject{ @adapter }
+
+    should have_imeths :reset_db
+
+    should "know how to reset the db" do
+      maintain_test_schema_called_with = nil
+      Assert.stub(ActiveRecord::Migration, :maintain_test_schema!) do |*args|
+        maintain_test_schema_called_with = args
+      end
+
+      subject.reset_db
+
+      exp = []
+      assert_equal exp, maintain_test_schema_called_with
+    end
+
+  end
+
+end

--- a/test/unit/assert-rails4_tests.rb
+++ b/test/unit/assert-rails4_tests.rb
@@ -1,0 +1,22 @@
+require "assert"
+require "assert-rails4"
+
+require "assert-rails4/adapter"
+
+module AssertRails4
+
+  class UnitTests < Assert::Context
+    desc "AssertRails4"
+    setup do
+      @module = AssertRails4
+    end
+    subject{ @module }
+
+    should "set AssetRails's adapter" do
+      exp = AssertRails4::Adapter
+      assert_instance_of exp, AssertRails.adapter
+    end
+
+  end
+
+end


### PR DESCRIPTION
This allows keeping the framework code in the assert-rails gem and
rolling adapter gems for logic that is specific to each major
version of Rails.

This includes the adapter logic/tests and a README write up for the
reset db API.

@jcredding ready for review.