### PR TITLE
implement the DbTests adapter API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@ require "assert-rails4"
 AssertRails.reset_db
 ```
 
+### Running database tests in a transaction
+
+```ruby
+# in test/helper.rb
+require "assert-rails4"
+class DbTests < AssertRails::DbTests
+  # put any extra setup / teardown logic here
+end
+```
+
+Then in a test that needs to interact with the database:
+
+```ruby
+require "assert"
+require "blog_record"
+
+class BlogRecord
+
+  class SystemTests < DbTests
+    # all tests in this context will be run in a transaction
+  end
+
+end
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/assert-rails4/adapter.rb
+++ b/lib/assert-rails4/adapter.rb
@@ -11,6 +11,14 @@ module AssertRails4
       ActiveRecord::Migration.maintain_test_schema!
     end
 
+    def transaction(&block)
+      ActiveRecord::Base.transaction(&block)
+    end
+
+    def rollback!
+      raise ActiveRecord::Rollback
+    end
+
   end
 
 end

--- a/test/unit/adapter_tests.rb
+++ b/test/unit/adapter_tests.rb
@@ -27,6 +27,7 @@ class AssertRails4::Adapter
     subject{ @adapter }
 
     should have_imeths :reset_db
+    should have_imeths :transaction, :rollback!
 
     should "know how to reset the db" do
       maintain_test_schema_called_with = nil
@@ -38,6 +39,24 @@ class AssertRails4::Adapter
 
       exp = []
       assert_equal exp, maintain_test_schema_called_with
+    end
+
+    should "know how to run a transaction block" do
+      ar_transaction_called = false
+      Assert.stub(ActiveRecord::Base, :transaction) do |&block|
+        ar_transaction_called = true
+        block.call
+      end
+
+      block_yielded_to = false
+      subject.transaction{ block_yielded_to = true }
+
+      assert_true ar_transaction_called
+      assert_true block_yielded_to
+    end
+
+    should "know how to trigger a transaction rollback" do
+      assert_raises(ActiveRecord::Rollback){ subject.rollback! }
     end
 
   end

--- a/test/unit/assert-rails4_tests.rb
+++ b/test/unit/assert-rails4_tests.rb
@@ -12,7 +12,7 @@ module AssertRails4
     end
     subject{ @module }
 
-    should "set AssetRails's adapter" do
+    should "set AssertRails's adapter" do
       exp = AssertRails4::Adapter
       assert_instance_of exp, AssertRails.adapter
     end

--- a/test/unit/db_tests_tests.rb
+++ b/test/unit/db_tests_tests.rb
@@ -1,0 +1,38 @@
+require "assert"
+require "assert-rails/db_tests"
+
+# Note: this is "unit" test that is acting like a "system-ish" test between
+# this adapter gem and AssertRails's DbTests.  It is a copy of the
+# same unit tests in AssertRails but instead of stubbing the adapter,
+# it stubs ActiveRecord directly.
+
+class AssertRails::DbTests
+
+  class UnitTests < Assert::Context
+    desc "AssertRails::DbTests"
+    setup do
+      @transaction_called = false
+      Assert.stub(ActiveRecord::Base, :transaction) do |&block|
+        @transaction_called = true
+        block.call
+      end
+
+      @class = AssertRails::DbTests
+    end
+    subject{ @class }
+
+    should "add an around callback to run tests in a rollback transaction" do
+      assert_equal 1, subject.arounds.size
+      callback = subject.arounds.first
+
+      block_yielded_to = false
+      assert_raises(ActiveRecord::Rollback) do
+        callback.call(proc{ block_yielded_to = true })
+      end
+      assert_true @transaction_called
+      assert_true block_yielded_to
+    end
+
+  end
+
+end


### PR DESCRIPTION
This enables running database tests in a transaction and rolling
back after the tests run.

This implements the adapter methods and adds a system-ish test for
AssertActiveRecord:DbTests stubbing ActiveRecord directly.

This also adds a README writeup on using DbTests since all usage
docs live in the adapter gems.

@jcredding ready for review.